### PR TITLE
Set file times to when diskfile was started

### DIFF
--- a/diskfile.c
+++ b/diskfile.c
@@ -14,6 +14,7 @@
 
 diskfile_entry diskfile_entries[DISKFILE_MAX_ENTRIES];
 size_t diskfile_entries_count = 0;
+time_t diskfile_time;
 
 static off_t
 diskfile_source_size(const char *path) {	
@@ -44,6 +45,9 @@ diskfile_getattr(const char *path, struct stat *stbuf) {
 			if (entry->size == -1)
 				entry->size = diskfile_source_size(entry->source);
 			stbuf->st_size = entry->size;
+			stbuf->st_ctime = diskfile_time;
+			stbuf->st_mtime = diskfile_time;
+			stbuf->st_atime = diskfile_time;
 			return 0;
 		}
 	}

--- a/diskfile.h
+++ b/diskfile.h
@@ -10,6 +10,7 @@ typedef struct {
 } diskfile_entry;
 extern diskfile_entry diskfile_entries[];
 extern size_t diskfile_entries_count;
+extern time_t diskfile_time;
 
 extern struct fuse_operations diskfile_operations;
 off_t diskfile_device_size(const char *path);

--- a/main.c
+++ b/main.c
@@ -54,5 +54,7 @@ int main(int argc, char* argv[]) {
 	// put the mountpoint back
 	fuse_opt_add_arg(&args, diskfile_entries[--diskfile_entries_count].source);
 
+	diskfile_time = time(NULL);
+
 	return fuse_main(args.argc, args.argv, &diskfile_operations, NULL);
 }


### PR DESCRIPTION
This is needed when using backup systems that check mtime; now
restarting diskfile will make the files appear fresh.
