### PR TITLE
Handle errors in diskfile_open() and diskfile_device_size()

### DIFF
--- a/diskfile.c
+++ b/diskfile.c
@@ -73,6 +73,8 @@ diskfile_open(const char *path, struct fuse_file_info *fi) {
 				return -EACCES;
 			
 			fi->fh = open(entry->source, O_RDONLY);
+			if (fi->fh == -1)
+				return -1;
 			return 0;
 		}
 	}

--- a/linux-size.c
+++ b/linux-size.c
@@ -10,7 +10,10 @@
 off_t diskfile_device_size(const char *path) {	
     unsigned long long size;
     int fd = open(path, O_RDONLY);
-    ioctl(fd, BLKGETSIZE64, &size);
+		if (fd == -1)
+			return 0;
+    if (ioctl(fd, BLKGETSIZE64, &size) == -1)
+			size = 0;
     close(fd);
     return size;
 }


### PR DESCRIPTION
File sizes are otherwise filled with junk if the device nodes were not
readable.
